### PR TITLE
Simplify job descriptions

### DIFF
--- a/job-descriptions/developer-advocate.md
+++ b/job-descriptions/developer-advocate.md
@@ -2,7 +2,7 @@
 
 # Developer Advocate
 
-### About the company
+### About us
 
 At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
 
@@ -11,38 +11,27 @@ We have already built the world's best [code search](https://about.sourcegraph.c
 
 Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
 
-### About the team
-
-Our small team consists of talented, mature, collaborative, driven individuals who are attracted to the massive problem we are tackling. We work in an open environment that treats people in a first-class manner and provides them with ownership, responsibility, and autonomy.
-
 ### Benefits
 
 In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive.
 
 ### About the role
 
-We are searching for an individual who wants to help every developer in the world get access to the best tools. The ideal candidate will be a developer, someone who understands the pains of searching for a piece of code on GitHub (or similar), the frustration of working in a code editor that doesn’t provide code intelligence (e.g., go to definition, hover tooltips, find references), or the time burned in re-configuring developer tools for a new open source project.
+We are searching for a teammate who wants to help every developer in the world get access to the best tools. The ideal candidate will be a developer, someone who understands the pains of searching for a piece of code on GitHub (or similar), the frustration of working in a code editor that doesn’t provide code intelligence (such as "go to definition"), or the time burned in re-configuring developer tools for a new project.
 
-We have built a product that our tens of thousands of users love, and you will help us bring it to tens of millions more.
+You will:
 
-### Responsibilities
-
-- Effectively communicate the value of Sourcegraph to developers who haven’t used it before.
+- Effectively communicate the value of Sourcegraph to developers who haven’t used it before (in person at events or through content).
 - Constantly be learning and experimenting with new developer tools and processes.
-- Provide a voice of the user to guide internal strategy and decision-making about Sourcegraph’s products.
+- Provide a voice of the user to guide internal strategy and decision-making.
 - Help the team write documentation that’s usable and clear for our target audience.
-- Write interesting content that developers would want to read.
-- Attend meetups, conferences, and other developer events.
 
 ### Ideal candidates have
 
-- Experience as a programmer, in order to understand the product and user need.
+- Experience as a programmer (limited, or as a hobby, is fine), in order to understand the product and user need.
 - A voracious appetite for learning about developer processes, and following new product offerings around the industry.
-- Strong public speaking skills.
-- A demonstrated ability to write about technical topics in an interesting, concise, and useful way.
-- A desire to meet new people and attend new events.
+- A demonstrated ability in either (or both) public speaking and presenting, or writing about technical topics in an interesting, concise, and useful way.
 - A willingness to learn on the job, and to try multiple, creative approaches to reach users.
-- A knack for giving and receiving feedback.
 
 ### Interview process
 
@@ -50,11 +39,11 @@ We have built a product that our tens of thousands of users love, and you will h
 2.  We schedule a 30 minute phone call to share what we are looking for in a candidate and to find out what you are looking for in your next role.
 3.  We collect a sample or samples of how you present and write. This could come from one or more sources:
 
-    - Blog posts from past jobs or personal experience.
     - A presentation to the Sourcegraph team on a technical topic.
     - A small content creation project we pay you to work on.
+    - Blog posts from past jobs or personal experience.
 
-4.  We conduct ~3 more interviews which can be on site or remote depending on the circumstances.
+4.  We invite you (or fly you out to our San Francisco office) for a few more interviews and to meet the team.
 5.  We check your references.
 6.  We make you a job offer.
 

--- a/job-descriptions/developer-advocate.md
+++ b/job-descriptions/developer-advocate.md
@@ -43,7 +43,7 @@ You will:
     - A small content creation project we pay you to work on.
     - Blog posts from past jobs or personal experience.
 
-4.  We invite you (or fly you out to our San Francisco office) for a few more interviews and to meet the team.
+4.  We schedule a few more hours interviews. We are happy to fly you out to our San Francisco office to meet the team in person, or to conduct the remaining interviews remotely, whatever works best for you.
 5.  We check your references.
 6.  We make you a job offer.
 

--- a/job-descriptions/growth-biz-ops.md
+++ b/job-descriptions/growth-biz-ops.md
@@ -41,7 +41,7 @@ You will:
 1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5HqQVTS8b53B).
 2.  We schedule a 30 minute phone call to share what we are looking for in a candidate and to find out what you are looking for in your next role.
 3.  We give you a small case study project to see how you would approach the job at Sourcegraph.
-4.  We invite you (or fly you out to our San Francisco office) for a few more interviews and to meet the team.
+4.  We schedule a few more hours interviews. We are happy to fly you out to our San Francisco office to meet the team in person, or to conduct the remaining interviews remotely, whatever works best for you.
 5.  We check your references.
 6.  We make you a job offer.
 

--- a/job-descriptions/growth-biz-ops.md
+++ b/job-descriptions/growth-biz-ops.md
@@ -2,7 +2,7 @@
 
 # Growth & Business Operations
 
-### About the company
+### About us
 
 At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
 
@@ -11,44 +11,40 @@ We have already built the world's best [code search](https://about.sourcegraph.c
 
 Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
 
-### About the team
+### Benefits
 
-Our small team consists of talented, mature, collaborative, driven individuals who are attracted to the massive problem we are tackling. We work in an open environment that treats people in a first-class manner and provides them with ownership, responsibility, and autonomy.
+In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive.
 
 ### About the role
 
 Every company in the world is a software company, and every developer in the world needs Sourcegraph. We are building a product that empowers developers, and are looking for someone who wants to help us bring the best development tools to every team in the world.
 
-We have demonstrated strong product-market fit, through signals such as customer engagement and usage metrics, satisfaction scores, and most importantly, sales to large enterprise customers. We have grown largely through word of mouth in the past, and are now looking to accelerate, while staying true to our authentic, bottom-up go-to-market model (we strive to learn from companies like Atlassian, Stripe, Hashicorp, Dropbox, GitLab, and more). The individual who fills this role will help us build a Growth and Analytics team from the ground up.
+We have demonstrated strong product-market fit, but have grown largely through word of mouth in the past. We are looking to accelerate, while staying true to our authentic, bottom-up go-to-market model (we strive to learn from companies like Atlassian, Stripe, Hashicorp, Dropbox, GitLab, and more).
 
-The ideal candidate will be excited by software development and the dev tools industry (no training as an Engineer required), have a strong analytical background, and bring creativity and a “fail fast” mentality to our Growth and Marketing efforts. We have built a product that our tens of thousands of users love; you will help us bring it to tens of millions more.
-
-### Responsibilities
+You will:
 
 - Help define, dissect, and optimize Sourcegraph’s user acquisition funnel and customer journey.
 - Think creatively about ways to grow or optimize different stages in the user journey/funnel.
 - Execute (this is not just a role for high-level consulting).
-- Be data-driven to quickly prioritize opportunities.
-- Work effectively cross-functionally (for example, work with Design, Engineering, and Product teams to run A/B tests).
-- Help our go-to-market teams (Developer Advocates and Sales) prioritize opportunities to invest their time.
-- Get to know and learn from Sourcegraph’s users, customers, and partners.
+- Be data-driven in helping our go-to-market teams (Developer Advocates and Sales) prioritize opportunities to invest their time.
+- Help build a growth and business team from the ground up.
 
 ### Ideal candidates have
 
+- A passion and excitement for software development (no training as an Engineer required) and growth.
 - Demonstrated background in analytical roles (BizOps, Consulting, Growth, Finance, etc.).
-- Creativity, and a willingness to try everything and iterate quickly (e.g. ideas that won’t scale or ideas that sound crazy at first).
-- Excitement and enthusiasm about building up a new function inside Sourcegraph.
-- Familiarity with SQL (or other languages/tools) for data analysis.
+- Familiarity with SaaS business models, and how software companies grow.
+- Creativity, and a willingness to try everything and iterate quickly (e.g. ideas that won’t scale or ideas that sound "crazy" at first).
 
 ### Interview process
 
 1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5HqQVTS8b53B).
 2.  We schedule a 30 minute phone call to share what we are looking for in a candidate and to find out what you are looking for in your next role.
-3.  We give you a small case study project to see how you would approach the job at Sourcegraph, and you present to the hiring manager.
-4.  We conduct ~3 more interviews on site.
+3.  We give you a small case study project to see how you would approach the job at Sourcegraph.
+4.  We invite you (or fly you out to our San Francisco office) for a few more interviews and to meet the team.
 5.  We check your references.
 6.  We make you a job offer.
 
 We also expect you to be interviewing us too, so ask us any questions you have along the way!
 
-[Click here to apply!](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5HqQVTS8b53B)
+**[Click here to apply!](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5HqQVTS8b53B)**

--- a/job-descriptions/product-designer.md
+++ b/job-descriptions/product-designer.md
@@ -2,7 +2,7 @@
 
 # Product Designer
 
-### About the company
+### About us
 
 At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
 
@@ -11,37 +11,29 @@ We have already built the world's best [code search](https://about.sourcegraph.c
 
 Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
 
-### About the team
-
-Our small team consists of talented, mature, collaborative, driven individuals who are attracted to the massive problem we are tackling. We work in an open environment that treats people in a first-class manner and provides them with ownership, responsibility, and autonomy.
-
 ### Benefits
 
 In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive.
 
 ### About the role
 
-We are searching for a creative, self-motivated visionary who can brainstorm ideas and bring them to life. We highly value design within our organization, as it impacts all aspects of Sourcegraph’s product. You'll have creative autonomy and a strong influence over the product’s development.
+We are searching for creative, self-motivated designers who can brainstorm ideas and bring them to life. We highly value design within our organization, as it impacts all aspects of Sourcegraph’s product. You'll have creative autonomy and a strong influence over the product’s development.
 
-### Responsibilities
+You will:
 
 - Contribute to overall strategy and decision-making about Sourcegraph’s features.
-- Provide hands-on support to users and customers.
 - Work closely and effectively communicate with our engineers to define, design, and improve Sourcegraph, ensuring a high-quality implementation.
-- Provide product vision in making Sourcegraph simple and more intuitive to use for developers and engineering managers.
 - Support multiple projects simultaneously while meeting tight deadlines.
-- Advise front-end engineers on UI implementation best practices.
 - Create designs that adhere to and extend the existing style guide.
 
 ### Ideal candidates have
 
-- A strong online portfolio to show off their skillset and years of experience designing digital products.
-- Experience as a programmer in order to understand the product and user need.
-- The ability to collaborate with several teams through all steps of the design process.
-- An understanding and passion of what makes great user experience.
-- The ability to learn quickly and succeed in a fast paced, iterative environment.
+- An understanding of and passion for what makes a great user experience.
+- A portfolio to show off their skillset and years of experience designing digital products.
+- Experience (limited, or as a hobby, is fine) as a programmer to understand the product and user need, and to jump into our codebase and fix design (e.g. CSS) issues.
 - A knack for giving and receiving feedback, and explaining the reasoning behind their designs.
-- Experience using Figma, Sketch or any other vector-based design tools to deliver product ideas from conception to mockups and finished renderings.
-- The ability to jump into our codebase and fix design issues.
+- Experience using Figma, Sketch, or any other vector-based design tools to deliver product ideas from conception to mockups and finished renderings.
 
-[Click here to apply!](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADE_fALePiTUX)
+### Interview process
+
+**[Click here to apply!](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADE_fALePiTUX)**

--- a/job-descriptions/software-engineer-intern.md
+++ b/job-descriptions/software-engineer-intern.md
@@ -2,7 +2,7 @@
 
 # Software Engineer Internship (San Francisco)
 
-### About the company
+### About us
 
 At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
 
@@ -11,26 +11,22 @@ We have already built the world's best [code search](https://about.sourcegraph.c
 
 Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
 
-### About the team
-
-Our small team consists of talented, mature, collaborative, driven individuals who are attracted to the massive problem we are tackling. We work in an open environment that treats people in a first-class manner and provides them with ownership, responsibility, and autonomy.
-
 ### About the role
 
-*This is a paid internship* 
+_This is a paid internship_
 
 As an intern, you will help build Sourcegraph, a multi-tier application (web, CLI, browser extensions, API, data stores, services) written primarily in TypeScript (frontend) and Go (backend). You will be matched with a mentor who will help plan your work, and then you will have responsibility and autonomy to get the work done.
-
-Ideal candidates:
-
-- Are pursuing a computer science undergraduate or graduate degree.
-- Can demonstrate passion and excitement about developer tools (e.g. have built a developer tool, contributed to open source developer tools or other open source projects, written blog posts or talks about development, etc.)
-- Have submitted a PR in any one of our repos (and linked to it in their application)!
 
 Example intern projects from past years:
 
 - Build a browser extension from scratch that communicates with the Sourcegraph API to inject code intelligence on http://github.com.
 - Build a Sourcegraph electron application that is synced with the cursor position in your editor via an editor extension.
 - Integrate Sourcegraph search into Alfred.
+
+### Ideal candidates:
+
+- Are pursuing a computer science undergraduate or graduate degree.
+- Can demonstrate passion and excitement about developer tools (e.g. have built a developer tool, contributed to open source developer tools or other open source projects, written blog posts or talks about development, etc.)
+- _(Not required)_ Have submitted a PR in any one of our repos (and linked to it in their application)!
 
 **[Click here to apply!](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5MmpnWT-Pu9h)**

--- a/job-descriptions/software-engineer-intern.md
+++ b/job-descriptions/software-engineer-intern.md
@@ -27,6 +27,5 @@ Example intern projects from past years:
 
 - Are pursuing a computer science undergraduate or graduate degree.
 - Can demonstrate passion and excitement about developer tools (e.g. have built a developer tool, contributed to open source developer tools or other open source projects, written blog posts or talks about development, etc.)
-- _(Not required)_ Have submitted a PR in any one of our repos (and linked to it in their application)!
 
 **[Click here to apply!](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5MmpnWT-Pu9h)**

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -2,7 +2,7 @@
 
 # Software Engineer (San Francisco or remote)
 
-### About the company
+### About us
 
 At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
 
@@ -11,13 +11,9 @@ We have already built the world's best [code search](https://about.sourcegraph.c
 
 Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
 
-### About the team
-
-Our small team consists of talented, mature, collaborative, driven individuals who are attracted to the massive problem we are tackling. We work in an open environment that treats people in a first-class manner and provides them with ownership, responsibility, and autonomy.
-
 ### Benefits
 
-In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive. 
+In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive.
 
 ### About the role
 
@@ -34,69 +30,21 @@ As a senior member of the team, you will:
 - Help set the technical direction of various projects.
 - Mentor and teach other team members.
 
-This is a full-stack role and ideal candidates should feel comfortable (though not equally skilled) contributing to any part of our codebase.
+Take a look at our public [near-term product roadmap](https://docs.sourcegraph.com/dev/roadmap) for examples of projects you could work on at Sourcegraph.
 
-#### Ideal candidates have
+### Ideal candidates have
 
 - A track record of delivering high-quality products with attention to scalability and UX.
 - Strong web/JavaScript/TypeScript/Go fundamentals.
 - Experience working with APIs and distributed systems.
 - Passion for the craft of software development and good engineering practices.
 
-#### Example projects
-
-As an engineer at Sourcegraph, you will have the opportunity to work on a wide variety of projects. It is also ok if you prefer to specialize.
-
-##### Web
-
-- Make our search results page infinite scroll without any visible latency or stuttering.
-- Create a sharable hover tooltip library that works on Sourcegraph.com as well as on all of the code hosts that we support (e.g. GitHub, GitLab, Bitbucket, Phabricator, etc.) via our browser extensions.
-- Implement auto-complete typeahead for search queries.
-- Write robust end-to-end tests for our website and browser extensions.
-- Create the Sourcegraph browser extension for Chrome, Firefox, and Safari.
-
-##### Clients
-
-- Create a `src` CLI command that makes it easy for customers to perform common operations against our APIs.
-- Create Sourcegraph editor extensions (e.g. Visual Studio Code, Atom, Intellij, Sublime) that allow developers to use Sourcegraph without breaking their flow.
-
-##### Backend
-
-- Create a system to perform fast, real-time, cross-repository `git grep`.
-- Create a platform that allows our customers to extend the functionality of Sourcegraph.
-- Make our code search and code intelligence scale to 10,000+ repositories and massive mono-repositories without overloading our customer's code hosts.
-- Add support for new code hosts to Sourcegraph.
-- Reduce P95 latency of requests to our API (e.g. hover tooltips, find references, go-to-definition).
-
-##### Operations
-
-- Streamline how customers configure and deploy Sourcegraph to a Kubernetes cluster.
-- Improve our CI infrastructure to be faster and more reliable.
-- Scale our Kubernetes cluster to meet traffic demands and avoid OOMs, while minimizing/optimizing the infrastructure costs for ourselves and for our customers.
-- Implement zero downtime deploys of Sourcegraph.
-- Standardize how we do logging and telemetry across all our systems.
-- Increase the observability of our systems so we can figure out what is wrong when issues are reported.
-
 ### Interview process
 
 1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADP_pY7jAAAXU).
-
-    - Please explain why you are interested in Sourcegraph.
-    - Try out our product (e.g. code search and browser extension) and let us know what feedback you have.
-    - If you have any non-trivial code samples that you can share with us (e.g. your own open source projects, or contributions to other projects) we would love to look at that.
-
-2.  We schedule a 30 minute introductory phone call to tell you more about Sourcegraph, to share what we are looking for in a candidate and to find out what you are looking for in your next role.
-    
-    Let us know if you are interested in doing a paid project with us. This gives you a chance to see the kind of real world problems that we work on and gives us another data point to consider in case interviews aren't your forte.
-
+2.  We schedule a 30 minute introductory phone call to tell you more about Sourcegraph, to share what we are looking for in a candidate, and to find out what you are looking for in your next role.
 3.  We schedule a 1 hour technical phone interview.
-    - We will write some code in a tool like https://coderpad.io.
-    - We avoid trick questions and problems that require a single epiphany to solve.
 4.  We fly you out to our San Francisco office for a few more hours of interviews and to meet the team.
-
-    - We will write some code in your preferred editor or in a tool like https://coderpad.io (not a whiteboard).
-    - We avoid trick questions and problems that require a single epiphany to solve.
-
 5.  We check your references.
 6.  We make you a job offer.
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -43,8 +43,11 @@ Take a look at our public [near-term product roadmap](https://docs.sourcegraph.c
 
 1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADP_pY7jAAAXU).
 2.  We schedule a 30 minute introductory phone call to tell you more about Sourcegraph, to share what we are looking for in a candidate, and to find out what you are looking for in your next role.
-3.  We schedule a 1 hour technical phone interview.
-4.  We fly you out to our San Francisco office for a few more hours of interviews and to meet the team.
+3.  We collect a code sample from one or more of the following sources:
+    - We review any existing public code that you have (e.g. your own projects, or your contributions to other projects).
+    - You work on a paid project with us.
+    - We schedule a 1 hour technical phone interview.
+4.  We schedule a few more hours of technical and non-technical interviews. We are happy to fly you out to our San Francisco office to meet the team in person, or to conduct the remaining interviews remotely, whatever works best for you.
 5.  We check your references.
 6.  We make you a job offer.
 


### PR DESCRIPTION
Most of these are pretty minimal, other than removing the bulk of example projects from the Eng position. I also removed some of the frivolous bullets/words in our "ideal candidates" lists on each position.