### PR TITLE
Update software-engineer.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,7 @@ Our team consists of talented, collaborative, driven individuals who are attract
 
 ### Our work
 
-View a few of our open-source projects to get an idea of some of the problems we are working on.
-
-- [Go language server for code intelligence](https://github.com/sourcegraph/go-langserver)
-- [JavaScript and TypeScript language server for code intelligence](https://github.com/sourcegraph/javascript-typescript-langserver)
+Most of our work, including our main product, is [open source](https://github.com/sourcegraph)! You can check out our code to see the kinds of problems that we work on, file an issue if you run into any problems, or even submit a PR if you want to help make Sourcegraph better.
 
 ### Benefits
 

--- a/job-descriptions/developer-advocate.md
+++ b/job-descriptions/developer-advocate.md
@@ -4,12 +4,11 @@
 
 ### About us
 
-At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
+At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner! You can read [our master plan](https://sourcegraph.com/plan) to learn about our mission.
 
-We have already built the world's best [code search](https://about.sourcegraph.com/docs/search/) that is used and loved by large and small engineering organizations across the world.
-[Sourcegraph](https://about.sourcegraph.com/product/server) and our [browser extensions](https://about.sourcegraph.com/product/browser) provide IDE-like code intelligence (e.g. hover tooltips, go to definition, find references, and much more) in your code host, in code review, and everywhere you read code.
+Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed to paying customers with small and large engineering organizations across the world. Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
 
-Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
+You can see all the progrees that we have made by reading [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are working on by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
 ### Benefits
 

--- a/job-descriptions/growth-biz-ops.md
+++ b/job-descriptions/growth-biz-ops.md
@@ -4,12 +4,11 @@
 
 ### About us
 
-At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
+At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner! You can read [our master plan](https://sourcegraph.com/plan) to learn about our mission.
 
-We have already built the world's best [code search](https://about.sourcegraph.com/docs/search/) that is used and loved by large and small engineering organizations across the world.
-[Sourcegraph](https://about.sourcegraph.com/product/server) and our [browser extensions](https://about.sourcegraph.com/product/browser) provide IDE-like code intelligence (e.g. hover tooltips, go to definition, find references, and much more) in your code host, in code review, and everywhere you read code.
+Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed to paying customers with small and large engineering organizations across the world. Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
 
-Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
+You can see all the progrees that we have made by reading [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are working on by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
 ### Benefits
 

--- a/job-descriptions/software-engineer-intern.md
+++ b/job-descriptions/software-engineer-intern.md
@@ -4,12 +4,11 @@
 
 ### About us
 
-At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
+At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner! You can read [our master plan](https://sourcegraph.com/plan) to learn about our mission.
 
-We have already built the world's best [code search](https://about.sourcegraph.com/docs/search/) that is used and loved by large and small engineering organizations across the world.
-[Sourcegraph](https://about.sourcegraph.com/product/server) and our [browser extensions](https://about.sourcegraph.com/product/browser) provide IDE-like code intelligence (e.g. hover tooltips, go to definition, find references, and much more) in your code host, in code review, and everywhere you read code.
+Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed to paying customers with small and large engineering organizations across the world. Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
 
-Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
+You can see all the progrees that we have made by reading [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are working on by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
 ### About the role
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -6,9 +6,9 @@
 
 At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner! You can read [our master plan](https://sourcegraph.com/plan) to learn about our mission.
 
-Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed at paying customers with small and large engineering organizations across the world! Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
+Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed to paying customers with small and large engineering organizations across the world. Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
 
-You can see all the progrees that we have been making by reading [our blog](https://about.sourcegraph.com/blog/) and all the exciting things that we are working by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
+You can see all the progrees that we have made by reading [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are working on by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
 ### Benefits
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -8,7 +8,7 @@ At Sourcegraph, we are building a better, smarter foundation for software develo
 
 Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed at paying customers with small and large engineering organizations across the world! Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
 
-You can see the progrees that we have been making by reading [our blog](https://about.sourcegraph.com/blog/) and what we are planning to work on next by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
+You can see all the progrees that we have been making by reading [our blog](https://about.sourcegraph.com/blog/) and all the exciting things that we are working by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
 ### Benefits
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -4,12 +4,11 @@
 
 ### About us
 
-At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner.
+At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner! You can read [our master plan](https://sourcegraph.com/plan) to learn about our mission.
 
-We have already built the world's best [code search](https://about.sourcegraph.com/docs/search/) that is used and loved by large and small engineering organizations across the world.
-[Sourcegraph](https://about.sourcegraph.com/product/server) and our [browser extensions](https://about.sourcegraph.com/product/browser) provide IDE-like code intelligence (e.g. hover tooltips, go to definition, find references, and much more) in your code host, in code review, and everywhere you read code.
+Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed at paying customers with small and large engineering organizations across the world! Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
 
-Read [our blog](https://about.sourcegraph.com/blog/) to see what more we have been working on recently and read [our master plan](https://sourcegraph.com/plan) to see where we are going!
+You can see the progrees that we have been making by reading [our blog](https://about.sourcegraph.com/blog/) and what we are planning to work on next by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
 ### Benefits
 


### PR DESCRIPTION
My primary goal here was to emphasize the fact that we are open source.

In the course of making edits, I had a desire to make the job description more timeless (so we don't have to come update the job description every time our product messaging changes). As such, I deferred description of the product to our homepage (which should always reflect the best way to introduce a new person to Sourcegraph).

If you like these changes, then I can make them to other job descriptions too.