### PR TITLE
Refresh job descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Most of our work, including our main product, is [open source](https://github.co
 
 Here are some of the benefits that we provide.
 
+#### 🏖️ Vacation
+
+We have a flexible vacation policy with mandatory annual vacation time that encourages our team to recharge when they need to. Read more about our philosophy on [mandatory vacation time](https://about.sourcegraph.com/blog/why-vacation-at-tech-companies-should-be-mandatory-better-code-happier-people).
+
 #### 🏥 Medical
 
 We offer high-quality medical and dental care for all full-time employees and their dependents.
@@ -31,10 +35,6 @@ We offer high-quality medical and dental care for all full-time employees and th
 #### 🏃 Wellness
 
 A healthy mind and body is imperative to doing your best work and living a healthy life. We offer an $85 monthly stipend that can be used at your discretion.
-
-#### 🏖️ Vacation
-
-We have a flexible vacation policy with mandatory annual vacation time that encourages our team to recharge when they need to. Read more about our philosophy on [mandatory vacation time](https://about.sourcegraph.com/blog/why-vacation-at-tech-companies-should-be-mandatory-better-code-happier-people).
 
 #### 👪 Family friendly
 

--- a/job-descriptions/forward-deployed-engineer.md
+++ b/job-descriptions/forward-deployed-engineer.md
@@ -50,6 +50,6 @@ We provide competitive pay and equity because we want you to act like a business
 
 We also expect you to be interviewing us too, so ask us any questions you have along the way.
 
-If you aren't ready to start interviewing, but are interested to stop by our San Francisco office to meet the team, let us know!
+If you aren't ready to start interviewing, but would like to stop by our San Francisco office to meet the team, let us know!
 
 **[Click here to apply](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5KSeSjyaujcb)**

--- a/job-descriptions/forward-deployed-engineer.md
+++ b/job-descriptions/forward-deployed-engineer.md
@@ -4,7 +4,7 @@
 
 ### About us
 
-Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
+Sourcegraph's mission is to enable every software developer to create technology using the best tools. The innovations of the future will all rely on software, so by empowering developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
 We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public. This transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 

--- a/job-descriptions/forward-deployed-engineer.md
+++ b/job-descriptions/forward-deployed-engineer.md
@@ -6,7 +6,7 @@
 
 Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
-We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public because this transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
+We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public. This transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 
 We value continuous progress and we release a new version of Sourcegraph every month. You can see all of the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are planning to work on by reading [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 

--- a/job-descriptions/forward-deployed-engineer.md
+++ b/job-descriptions/forward-deployed-engineer.md
@@ -4,18 +4,15 @@
 
 ### About us
 
-At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code and by empowering software developers today, we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
+Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
-Our product (code search, code intelligence, browser extensions, etc.) is [open
-source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed
-to paying customers with small and large engineering organizations across the world. Visit [our
-homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
+We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public because this transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 
-You can see all the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are working on by checking out [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
+We value continuous progress and we release a new version of Sourcegraph every month. You can see all of the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are planning to work on by reading [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
-### Benefits
+Sourcegraph is an equal opportunity workplace; we embrace diversity and welcome people from all backgrounds and communities.
 
-In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive.
+If you are passionate about making the world better through software, come join us!
 
 ### About the role
 
@@ -38,22 +35,21 @@ You will:
   in a rapidly growing business.
 - Future entrepreneurial ambitions.
 
+### Compensation and benefits
+
+We provide competitive pay and equity because we want you to act like a business owner and share in the success of Sourcegraph. We also provide [many benefits](../README.md#benefits) to keep you happy, healthy, and productive.
+
 ### Interview process
 
 1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5KSeSjyaujcb).
-1.  1. We set up a 30 minute call to chat with you about Sourcegraph and to find out what you are looking for in your next role.
-1.  We give you a take home coding assignment which won't take you more than 2 hours to finish.
+1.  We set up a 30 minute call to chat with you about Sourcegraph and to find out what you are looking for in your next role.
+1.  We evaluate relevant technical skills that you have via a remote interview or async coding exercise.
 1.  We schedule a few more hours of technical and non-technical interviews. We're happy to fly you out to our San Francisco office, or conduct the remaining interviews over video chat, whatever works best for you.
 1.  We check your references.
 1.  We make you a job offer.
 
 We also expect you to be interviewing us too, so ask us any questions you have along the way.
 
-If you aren't ready to start interviewing, but are interested to stop by our San Francisco office to
-meet the team, let us know!
-
-
-Sourcegraph is an equal opportunity workplace, we embrace diversity and welcome people from all backgrounds and communities.
-
+If you aren't ready to start interviewing, but are interested to stop by our San Francisco office to meet the team, let us know!
 
 **[Click here to apply](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5KSeSjyaujcb)**

--- a/job-descriptions/growth-biz-ops.md
+++ b/job-descriptions/growth-biz-ops.md
@@ -4,15 +4,15 @@
 
 ### About us
 
-At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code. By empowering software developers today, we can bring the future sooner! You can read [our master plan](https://sourcegraph.com/plan) to learn about our mission.
+Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
-Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed to paying customers with small and large engineering organizations across the world. Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
+We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public because this transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 
-You can see all the progress that we have made by reading [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are working on by reading our [product roadmap](https://docs.sourcegraph.com/dev/roadmap).
+We value continuous progress and we release a new version of Sourcegraph every month. You can see all of the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are planning to work on by reading [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
-### Benefits
+Sourcegraph is an equal opportunity workplace; we embrace diversity and welcome people from all backgrounds and communities.
 
-In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive.
+If you are passionate about making the world better through software, come join us!
 
 ### About the role
 
@@ -34,6 +34,10 @@ You will:
 - Demonstrated background in analytical roles (BizOps, Growth, Consulting, Finance, etc.).
 - Familiarity with SaaS business models, and how software companies grow.
 - Creativity, and a willingness to try everything and iterate quickly (e.g. ideas that won’t scale or ideas that sound "crazy" at first).
+
+### Compensation and benefits
+
+We provide competitive pay and equity because we want you to act like a business owner and share in the success of Sourcegraph. We also provide [many benefits](../README.md#benefits) to keep you happy, healthy, and productive.
 
 ### Interview process
 

--- a/job-descriptions/growth-biz-ops.md
+++ b/job-descriptions/growth-biz-ops.md
@@ -4,7 +4,7 @@
 
 ### About us
 
-Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
+Sourcegraph's mission is to enable every software developer to create technology using the best tools. The innovations of the future will all rely on software, so by empowering developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
 We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public. This transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 

--- a/job-descriptions/growth-biz-ops.md
+++ b/job-descriptions/growth-biz-ops.md
@@ -6,7 +6,7 @@
 
 Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
-We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public because this transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
+We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public. This transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 
 We value continuous progress and we release a new version of Sourcegraph every month. You can see all of the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are planning to work on by reading [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -50,6 +50,6 @@ We provide competitive pay and equity because we want you to act like a business
 
 We also expect you to be interviewing us too, so ask us any questions you have along the way.
 
-If you aren't ready to start interviewing, but are interested to stop by our San Francisco office to meet the team, let us know!
+If you aren't ready to start interviewing, but would like to stop by our San Francisco office to meet the team, let us know!
 
 **[Click here to apply](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADP_pY7jAAAXU)**

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -19,7 +19,7 @@ If you are passionate about making the world better through software, come join 
 You will help build Sourcegraph, a code search and navigation product that scales to tens of thousands of repositories and massive monorepos. Here are some of the technologies that we use:
 
 - Frontend: TypeScript, React, RxJS, SCSS, Browser extension APIs
-- Backend: Go, GraphQL, Kubernetes, Docker
+- Backend: Go, GraphQL, PostgreSQL, Redis, Kubernetes, Docker
 
 We expect that you are skilled in one or more of these (or related) technologies and that you are interested in growing and expanding your expertise.
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -43,7 +43,7 @@ We provide competitive pay and equity because we want you to act like a business
 
 1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADP_pY7jAAAXU).
 1.  We set up a 30 minute call to chat with you about Sourcegraph to find out what you are looking for in your next role.
-1.  We evaluate relavant technical skills that you have via a remote interview or async coding exercise.
+1.  We evaluate relevant technical skills that you have via a remote interview or async coding exercise.
 1.  We schedule a few more hours of technical and non-technical interviews. We're happy to fly you out to our San Francisco office, or conduct the remaining interviews over video chat, whatever works best for you.
 1.  We check your references.
 1.  We make you a job offer.

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -4,7 +4,7 @@
 
 ### About us
 
-Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
+Sourcegraph's mission is to enable every software developer to create technology using the best tools. The innovations of the future will all rely on software, so by empowering developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
 We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public. This transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -1,48 +1,49 @@
 ![logo](https://sourcegraph.com/.assets/img/sourcegraph-light-head-logo.svg)
 
-# Software Engineer (San Francisco or remote)
+# Software Engineer
 
 ### About us
 
-At Sourcegraph, we are building a better, smarter foundation for software development. The innovations of the future will all rely on code and by empowering software developers today, we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
+Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
-Our product (code search, code intelligence, browser extensions, etc.) is [open source](https://about.sourcegraph.com/blog/sourcegraph-is-now-open-source), and is already deployed to paying customers with small and large engineering organizations across the world. Visit [our homepage](https://sourcegraph.com/start) to learn why companies use Sourcegraph.
+We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public because this transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 
-You can see all the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are working on by checking out [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
+We value continuous progress and we release a new version of Sourcegraph every month. You can see all of the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are planning to work on by reading [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 
-### Benefits
+Sourcegraph is an equal opportunity workplace; we embrace diversity and welcome people from all backgrounds and communities.
 
-In addition to competitive pay and equity, [we provide many benefits](https://github.com/sourcegraph/careers#benefits) to keep you happy, healthy, and productive.
+If you are passionate about making the world better through software, come join us!
 
 ### About the role
 
-You will:
+You will help build Sourcegraph, a code search and navigation product that scales to tens of thousands of repositories and massive monorepos. Here are some of the technologies that we use:
 
-- Help build Sourcegraph, a multi-tier application (web, CLI, browser extensions, API, data stores, services) written primarily in TypeScript (frontend) and Go (backend).
-- Have the freedom to creatively tackle various CS challenges while building products and infrastructure that are fundamental to the growth and success of the business.
-- Have the opportunity to interact directly with our customers to help them deploy/configure our software, and solve issues that they encounter.
+- Frontend: TypeScript, React, RxJS, SCSS, Browser extension APIs
+- Backend: Go, GraphQL, Kubernetes, Docker
+
+We expect that you are skilled in one or more of these (or related) technologies and that you are interested in growing and expanding your expertise.
+
+You will work on a small team that has focused goals and apply your skills to creatively build and own products and infrastructure that are fundamental to the growth and success of our business while following good engineering practices.
+
+We will encourage and help you to:
+
+- Interact directly with our customers to help them deploy/configure our software, and solve issues that they encounter.
 - Plan your own work each month based on company goals and customer feedback.
 - Publish blog posts and give conference talks about your work at Sourcegraph.
 
-As a senior member of the team, you will:
+### Location
 
-- Help set the technical direction of various projects.
-- Mentor and teach other team members.
+We are flexible. Our engineering team is distributed across the world and about half of them work from our office in San Francisco.
 
-Take a look at our public [near-term product roadmap](https://docs.sourcegraph.com/dev/roadmap) for examples of projects you could work on at Sourcegraph.
+### Compensation and benefits
 
-### Ideal candidates have
-
-- A track record of delivering high-quality products with attention to scalability and UX.
-- Strong web/JavaScript/TypeScript/Go fundamentals.
-- Experience working with APIs and distributed systems.
-- Passion for the craft of software development and good engineering practices.
+We provide competitive pay and equity because we want you to act like a business owner and share in the success of Sourcegraph. We also provide [many benefits](../README.md#benefits) to keep you happy, healthy, and productive.
 
 ### Interview process
 
 1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADP_pY7jAAAXU).
 1.  We set up a 30 minute call to chat with you about Sourcegraph to find out what you are looking for in your next role.
-1.  We give you a take home coding assignment which won't take you more than 2 hours to finish.
+1.  We evaluate relavant technical skills that you have via a remote interview or async coding exercise.
 1.  We schedule a few more hours of technical and non-technical interviews. We're happy to fly you out to our San Francisco office, or conduct the remaining interviews over video chat, whatever works best for you.
 1.  We check your references.
 1.  We make you a job offer.
@@ -50,10 +51,5 @@ Take a look at our public [near-term product roadmap](https://docs.sourcegraph.c
 We also expect you to be interviewing us too, so ask us any questions you have along the way.
 
 If you aren't ready to start interviewing, but are interested to stop by our San Francisco office to meet the team, let us know!
-
-
-
-Sourcegraph is an equal opportunity workplace; we embrace diversity and welcome people from all backgrounds and communities.
-
 
 **[Click here to apply](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAADP_pY7jAAAXU)**

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -33,7 +33,7 @@ We will encourage and help you to:
 
 ### Location
 
-We are flexible. Our engineering team is distributed across the world and about half of them work from our office in San Francisco.
+We are flexible. Our engineering team is distributed across the world and about half work from our office in San Francisco.
 
 ### Compensation and benefits
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -1,6 +1,6 @@
 ![logo](https://sourcegraph.com/.assets/img/sourcegraph-light-head-logo.svg)
 
-# Software Engineer
+# Software Engineer (San Francisco or remote)
 
 ### About us
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -6,7 +6,7 @@
 
 Sourcegraph is on a mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. The innovations of the future will all rely on software, so by empowering software developers today we can bring the future sooner. You can learn more about our mission by reading our [our master plan](https://sourcegraph.com/plan).
 
-We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public because this transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
+We are an [open company](https://docs.sourcegraph.com/dev/open_source_open_company): our code, our product roadmap, and our company processes are public. This transparency helps us rapidly gather feedback, iterate, learn, and deliver the best product to our customers.
 
 We value continuous progress and we release a new version of Sourcegraph every month. You can see all of the progress that we have made by visiting [our blog](https://about.sourcegraph.com/blog/), and all the exciting things that we are planning to work on by reading [our product roadmap](https://docs.sourcegraph.com/dev/roadmap).
 


### PR DESCRIPTION
I took a fresh look at our SWE job description and am proposing a few changes.

For "About us", I want to emphasize our mission and values more, because this is what seems to resonate most with candidates. If you agree, I would be happy to make these changes to all of the other job descriptions too.

For "About the role", I want to be clearer about what skills are expected and the fact that it is ok to have some subset of those skills. I removed the reference to "senior member of the team" to make this job description appeal to a broader audience and reflect the fact that we don't have titles.

For "Compensation and benefits" I want to elaborate on our philosophy and lift vacation to the top of the benefits list. If you agree, I would be happy to make these changes to all of the other job descriptions too.

I also updated the third step in our interview process to be a bit more opened ended since we are experimenting with a few things.