### PR TITLE
clarify no location or timezone requirements

### DIFF
--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -33,7 +33,7 @@ We will encourage and help you to:
 
 ### Location
 
-We are flexible. Our engineering team is distributed across the world and about half work from our office in San Francisco.
+We are flexible and don't require you to be in any particular timezone or location. Our engineering team is distributed across the world and about half work from our office in San Francisco.
 
 ### Compensation and benefits
 


### PR DESCRIPTION
A candidate asked if we were open to remote from APAC, even after reading our job description.

> My assumption comes from many applications at many companies that offer remote but only when you get past the resume screen do you find out that it is limited to certain timezones or certain countries due to legal/hr restrictions.

This change clarifies that we don't have any restrictions on location or timezone.