### PR TITLE
Add Software Engineer - Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Join us on our mission to make it so everyone, in every community, in every coun
 
 We're hiring! Check out our open positions:
 
-- [Software Engineer](job-descriptions/software-engineer.md) (frontend, backend, full stack, dev ops, site reliability, and/or customer facing)
-- [Software Engineer Intern](job-descriptions/software-engineer-intern.md)
+- [Software Engineer](job-descriptions/software-engineer.md) (frontend, backend, full stack)
+- [Software Engineer Intern](job-descriptions/software-engineer-intern.md) (frontend, backend, full stack)
+- [Software Engineer - Infrastructure](job-descriptions/software-engineer-infrastructure.md) (dev ops, CI/CD, site reliability)
 - [Account Executive](https://github.com/sourcegraph/careers/blob/master/job-descriptions/account-executive.md)
 - [UX Designer](https://github.com/sourcegraph/careers/blob/master/job-descriptions/ux-designer.md)
 

--- a/job-descriptions/software-engineer-infrastructure.md
+++ b/job-descriptions/software-engineer-infrastructure.md
@@ -1,0 +1,80 @@
+![logo](https://sourcegraph.com/.assets/img/sourcegraph-light-head-logo.svg)
+
+# Software Engineer - Infrastructure
+
+### About us
+
+We're building the new standard developer platform. Top tech companies have invested \$100Ms to build internal developer platforms for code search, code review, alerts, and automation. Sourcegraph provides this standard developer platform to every company, helping startups and large enterprises ship better software faster.
+
+[Our mission](https://sourcegraph.com/plan) is to dramatically increase the number of people who can understand and write code. By making code more accessible, we will democratize software development and accelerate innovations that bring the future sooner in transportation, health care, energy, AI, communication, space travel, etc.
+
+We value openness and transparency. [Our code](https://github.com/sourcegraph/sourcegraph), [our roadmap](https://about.sourcegraph.com/direction), and [our company processes](https://about.sourcegraph.com/company/open_source_open_company) are public. This transparency helps us rapidly gather feedback from our customers so we can iterate, learn, and deliver the best product.
+
+To create a product that serves the needs of all developers, we are building a diverse remote-first team that is distributed across the world. Sourcegraph is an equal opportunity workplace; we welcome people from all backgrounds and communities.
+
+If you are passionate about making the world better through software, come join us!
+
+### About the role
+
+You will be responsible for how Sourcegraph is built, deployed, and monitored, on customer instances and on Sourcegraph.com (the largest Sourcegraph installation in the world).
+
+Review the [Distribution team's roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.mi8zg2ql2uc6) to see the challenges that we are solving today and the challenges that we plan to solve in the future.
+
+- Deployment and operations: Kubernetes, Docker, Google Cloud Platform, Terraform
+
+#### Responsibilities
+
+You will:
+
+- Develop and maintain our CI/CD infrastructure so that builds are fast, reliable, and reproducible, and releases are boring and automated.
+- Design how Sourcegraph is packaged and deployed so that it can be deployed on-premise at any customer with ease, regardless of the customer's environment.
+- Define and capture metrics and logs that are used to monitor the heath and performance of Sourcegraph instances.
+- Dive into our application code when necessary to improve the performance, reliability, and observability of Sourcegraph.
+- Clearly document and automate how customers provision and scale Sourcegraph instances.
+- Run our on-call rotation to respond to operational incidents on Sourcegraph.com and at our largest customers.
+- Write [RFCs](https://about.sourcegraph.com/handbook/engineering/rfcs) to communicate your implementation plans and solicit feedback from teammates.
+- Collaborate directly with customers to troubleshoot deployment and configuration issues.
+
+We will encourage and support you to:
+
+- Publish blog posts and give conference talks about your work at Sourcegraph.
+
+#### Qualifications
+
+- You are comfortable using Go and Terraform to build tooling and automation.
+- You understand how Kubernetes works and are an expert at configuring and deploying non-trivial applications using Kubernetes on one or more compute infrastructure providers: GCP (preferred), AWS, Azure, Digital Ocean.
+- You are an expert in at least one CI system (Buildkite, TravisCI, etc.) and know how to achieve optimal build times without sacrificing reproducible builds.
+- You communicate clearly, especially in writing, and know how to write clear documentation.
+- You are passionate about creating high-quality software and understand how to make appropriate tradeoffs (e.g. cut scope) to ship quickly when necessary.
+- Your are happy and effective working collaboratively on a team to solve challenging open-ended engineering problems.
+
+#### Nice to haves
+
+- You have published blog posts and given conference talks about your past work.
+
+### Location
+
+We are flexible and don't require you to be in any particular timezone or location. Our engineering team is distributed across the world.
+
+### Compensation and benefits
+
+We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/people-ops/compensation) because we want you to act like a business owner and share in the success of Sourcegraph. We also provide [many benefits](https://about.sourcegraph.com/handbook/people-ops/benefits-and-perks) to keep you happy, healthy, and productive.
+
+### Interview process
+
+1.  You [apply here]().
+1.  We set up a 30 minute call to chat with you about Sourcegraph to find out what you are looking for in your next role.
+1.  We evaluate relevant technical skills that you have via a 2 hour coding exercise asynchronously at a time of your choosing.
+1.  We schedule a 4 hours of remote interviews over video chat across multiple days.
+    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
+    - **Technical experience:** We ask you about your past work and accomplishments.
+    - **Team collaboration:** We ask you about how you work and communciate in a team setting, and how you handle tricky situations.
+    - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
+1.  We check your references.
+1.  We make you a job offer.
+
+We also expect you to be interviewing us too, so ask us any questions you have along the way.
+
+If you aren't ready to start interviewing but are interested chat with us about anything, reach out to us [@srcgraph](https://twitter.com/srcgraph) or hiring@sourcegraph.com.
+
+**[Click here to apply]()**

--- a/job-descriptions/software-engineer-infrastructure.md
+++ b/job-descriptions/software-engineer-infrastructure.md
@@ -26,7 +26,7 @@ You will:
 
 - Develop and maintain our CI/CD infrastructure so that builds are fast, reliable, and reproducible, and releases are boring and automated.
 - Design how Sourcegraph is packaged and deployed so that it can be deployed on-premise at any customer with ease, regardless of the customer's environment.
-- Define and capture metrics and logs that are used to monitor the heath and performance of Sourcegraph instances.
+- Define and capture metrics and logs that are used to monitor the health and performance of Sourcegraph instances.
 - Dive into our application code when necessary to improve the performance, reliability, and observability of Sourcegraph.
 - Clearly document and automate how customers provision and scale Sourcegraph instances.
 - Run our on-call rotation to respond to operational incidents on Sourcegraph.com and at our largest customers.

--- a/job-descriptions/software-engineer-infrastructure.md
+++ b/job-descriptions/software-engineer-infrastructure.md
@@ -20,8 +20,6 @@ You will be responsible for how Sourcegraph is built, deployed, and monitored, o
 
 Review the [Distribution team's roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.mi8zg2ql2uc6) to see the challenges that we are solving today and the challenges that we plan to solve in the future.
 
-- Deployment and operations: Kubernetes, Docker, Google Cloud Platform, Terraform
-
 #### Responsibilities
 
 You will:

--- a/job-descriptions/software-engineer-infrastructure.md
+++ b/job-descriptions/software-engineer-infrastructure.md
@@ -67,13 +67,13 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 1.  We schedule a 4 hours of remote interviews over video chat across multiple days.
     - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
     - **Technical experience:** We ask you about your past work and accomplishments.
-    - **Team collaboration:** We ask you about how you work and communciate in a team setting, and how you handle tricky situations.
+    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
     - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
 1.  We check your references.
 1.  We make you a job offer.
 
 We also expect you to be interviewing us too, so ask us any questions you have along the way.
 
-If you aren't ready to start interviewing but are interested chat with us about anything, reach out to us [@srcgraph](https://twitter.com/srcgraph) or hiring@sourcegraph.com.
+If you aren't ready to start interviewing but are interested to chat with us about anything, reach out to us [@srcgraph](https://twitter.com/srcgraph) or hiring@sourcegraph.com.
 
 **[Click here to apply](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5E303MXJieJl?trackingTag=careersRepository)**

--- a/job-descriptions/software-engineer-infrastructure.md
+++ b/job-descriptions/software-engineer-infrastructure.md
@@ -48,7 +48,8 @@ We will encourage and support you to:
 
 #### Nice to haves
 
-- You have published blog posts and given conference talks about your past work.
+- You have published blog posts and/or given conference talks about your past work.
+- You have experience working on high-performing teams, preferable tech startups.
 
 ### Location
 

--- a/job-descriptions/software-engineer-infrastructure.md
+++ b/job-descriptions/software-engineer-infrastructure.md
@@ -61,7 +61,7 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 
 ### Interview process
 
-1.  You [apply here]().
+1.  You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5E303MXJieJl?trackingTag=careersRepository).
 1.  We set up a 30 minute call to chat with you about Sourcegraph to find out what you are looking for in your next role.
 1.  We evaluate relevant technical skills that you have via a 2 hour coding exercise asynchronously at a time of your choosing.
 1.  We schedule a 4 hours of remote interviews over video chat across multiple days.
@@ -76,4 +76,4 @@ We also expect you to be interviewing us too, so ask us any questions you have a
 
 If you aren't ready to start interviewing but are interested chat with us about anything, reach out to us [@srcgraph](https://twitter.com/srcgraph) or hiring@sourcegraph.com.
 
-**[Click here to apply]()**
+**[Click here to apply](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5E303MXJieJl?trackingTag=careersRepository)**

--- a/job-descriptions/software-engineer-infrastructure.md
+++ b/job-descriptions/software-engineer-infrastructure.md
@@ -42,7 +42,7 @@ We will encourage and support you to:
 - You are comfortable using Go and Terraform to build tooling and automation.
 - You understand how Kubernetes works and are an expert at configuring and deploying non-trivial applications using Kubernetes on one or more compute infrastructure providers: GCP (preferred), AWS, Azure, Digital Ocean.
 - You are an expert in at least one CI system (Buildkite, TravisCI, etc.) and know how to achieve optimal build times without sacrificing reproducible builds.
-- You communicate clearly, especially in writing, and know how to write clear documentation.
+- You communicate clearly, especially in writing, and know how to write excellent documentation.
 - You are passionate about creating high-quality software and understand how to make appropriate tradeoffs (e.g. cut scope) to ship quickly when necessary.
 - Your are happy and effective working collaboratively on a team to solve challenging open-ended engineering problems.
 

--- a/job-descriptions/software-engineer.md
+++ b/job-descriptions/software-engineer.md
@@ -16,7 +16,7 @@ If you are passionate about making the world better through software, come join 
 
 ### About the role
 
-You will help build Sourcegraph by collaborating on a small team to solve challenging problems that are fundamental to the growth and success of our business. This single job description covers a broad range of skillsets that we value at Sourcegraph (e.g. frontend, backend, full stack, dev ops, site reliability) so please don't hesitate to apply.
+You will help build Sourcegraph by collaborating on a small team to solve challenging problems that are fundamental to the growth and success of our business.
 
 We use a variety of technologies to help us accomplish our goals:
 


### PR DESCRIPTION
This adds a dedicated job description for an infrastructure role. I am open to suggestions if there is a more standard name for the role I am describing.

My intent is to further split the existing generic SWE job description into two more roles: frontend and backend, but I wanted to get this one out for review (and merged) first.

TODO
- [x] Add links to Google Hire