### PR TITLE
do not require Go experience for distribution candidates

### DIFF
--- a/job-descriptions/software-engineer-distribution.md
+++ b/job-descriptions/software-engineer-distribution.md
@@ -22,7 +22,7 @@ As a member of the [distribution team](https://about.sourcegraph.com/handbook/en
 
 We are looking for candidates with the following skills:
 
-- Comfortable using Go and Terraform (or similar infrastructure-as-code) to build tooling and automation for deployments, CI, and internal dev tools.
+- Comfortable using Terraform (or similar infrastructure-as-code) to build tooling and automation for deployments, CI, and internal dev tools.
 - Solid understanding of how to use Docker and Kubernetes to deploy non-trivial applications to cloud platorm providers (e.g. GCP, AWS).
 - Skilled at debugging customer problems followed by designing and implementing solutions to those problems.
 - Ability to communicate clearly and empathetically, especially in writing and documentation.
@@ -30,6 +30,7 @@ We are looking for candidates with the following skills:
 
 ### Nice-to-haves
 
+- Proficiency in Go.
 - Published blog posts and/or tech talks about your work.
 - Experience working on high-performing teams, preferably tech startups.
 


### PR DESCRIPTION
I do not think we should make Go experience a strict requirement for the backend and distribution roles. Prior experience will definitely shorten the ramp-up period, but I think there are a lot of people who would meet our technical bar, but who do not necessarily have Go experience.