### PR TITLE
Separate code exercise descriptions

### DIFF
--- a/job-descriptions/code-exercise-go.md
+++ b/job-descriptions/code-exercise-go.md
@@ -1,0 +1,12 @@
+# Go code exercise
+
+We designed this exercise to measure your understanding of HTTP requests, concurrency, and error handling.
+
+- You will choose a two hour timeframe to independently work on the exercise. You can choose any day and time; we just schedule an email.
+- At your chosen date and time, we will send you detailed instructions. You will be building a simple API server in Go that calls a JSON endpoint of another service and exposes a JSON endpoint of its own.
+- You should have a recent version of Go installed on your computer.
+- You can look up documentation on the internet while you are coding.
+- You are not prohibited from using open-source libries, but the problem is easily solved using only the Go standard library.
+- After two hours, you will email us your solution as a zip file and we will get back to you on next steps within 2 business days.
+
+If we have questions about your code, we might schedule a 30-minute followup call.

--- a/job-descriptions/code-exercise-go.md
+++ b/job-descriptions/code-exercise-go.md
@@ -2,7 +2,7 @@
 
 We designed this exercise to measure your understanding of HTTP requests, concurrency, and error handling.
 
-- You will choose a two hour timeframe to independently work on the exercise. You can choose any day and time; we just schedule an email.
+- You will choose a two hour timeframe to independently work on the exercise. You can choose any day and time that works for you; there are no scheduling constraints.
 - At your chosen date and time, we will send you detailed instructions. You will be building a simple API server in Go that calls a JSON endpoint of another service and exposes a JSON endpoint of its own.
 - You should have a recent version of Go installed on your computer.
 - You can look up documentation on the internet while you are coding.

--- a/job-descriptions/code-exercise-typescript.md
+++ b/job-descriptions/code-exercise-typescript.md
@@ -1,0 +1,12 @@
+# TypeScript code exercise
+
+We designed this exercise to measure your understanding of how callbacks and asyncronous execution works.
+
+- You will choose a two hour timeframe to independently work on the exercise. You can choose any day and time; we just schedule an email.
+- At your chosen date and time, we will send you a zipped TypeScript project that contains instructions and some unit tests.
+- You should have Node.js (>=8.16.0) installed on your computer.
+- You can look up documentation on the internet while you are coding.
+- You may use open-source libraries, but most candidates don't find it necessary.
+- After two hours, you will email us your solution as a zip file and we will get back to you on next steps within 2 business days.
+
+If we have questions about your code, we might schedule a 30-minute followup call.

--- a/job-descriptions/software-engineer-backend.md
+++ b/job-descriptions/software-engineer-backend.md
@@ -48,11 +48,8 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 ## Interview process
 
 1. You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5L45-sI42r_n?trackingTag=careersRepository).
-1. We set up a 30 minute call to answer any questions that you have about Sourcegraph.
-1. We evaluate relevant technical skills that you have via an asynchronous coding exercise.
-   - We will give you an overview of the exercise in advance.
-   - We will send you the details at a time of your choosing and you will have up to 2 hours to work on the exercise.
-   - You will be able to use your own development environment and lookup documentation on the internet.
+1. We set up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. You complete a 2-hour [coding exercise in Go](code-exercise-go.md) that we designed to measure your understanding of concurrency and error handling.
 1. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
    - **Technical experience:** We ask you about your past work and accomplishments.

--- a/job-descriptions/software-engineer-backend.md
+++ b/job-descriptions/software-engineer-backend.md
@@ -48,7 +48,7 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 ## Interview process
 
 1. You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5L45-sI42r_n?trackingTag=careersRepository).
-1. We set up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. We set up a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
 1. You complete a 2-hour [coding exercise in Go](code-exercise-go.md) that we designed to measure your understanding of concurrency and error handling.
 1. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.

--- a/job-descriptions/software-engineer-code-intelligence.md
+++ b/job-descriptions/software-engineer-code-intelligence.md
@@ -47,7 +47,7 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 ## Interview process
 
 1. You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5LkU-W2aD8Bg?trackingTag=careersRepository).
-1. We set up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. We set up a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
 1. You complete a 2-hour coding exercise in [TypeScript](code-exercise-typescript.md), or [Go](code-exercise-go.md). Click those links to learn more about the exercises. If you are not comfortable with either of these languages, we will figure something out.
 1. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.

--- a/job-descriptions/software-engineer-code-intelligence.md
+++ b/job-descriptions/software-engineer-code-intelligence.md
@@ -47,11 +47,8 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 ## Interview process
 
 1. You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5LkU-W2aD8Bg?trackingTag=careersRepository).
-1. We set up a 30 minute call to answer any questions that you have about Sourcegraph.
-1. We evaluate relevant technical skills that you have via an asynchronous coding exercise.
-   - We will give you an overview of the exercise in advance.
-   - We will send you the details at a time of your choosing and you will have up to 2 hours to work on the exercise.
-   - You will be able to use your own development environment and lookup documentation on the internet.
+1. We set up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. You complete a 2-hour coding exercise in [TypeScript](code-exercise-typescript.md), or [Go](code-exercise-go.md). Click those links to learn more about the exercises. If you are not comfortable with either of these languages, we will figure something out.
 1. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
    - **Technical experience:** We ask you about your past work and accomplishments.

--- a/job-descriptions/software-engineer-frontend.md
+++ b/job-descriptions/software-engineer-frontend.md
@@ -46,13 +46,8 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 ## Interview process
 
 1. You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5LV8Nx5OHMF9?trackingTag=careersRepository).
-1. We set up a 30 minute call to answer any questions that you have about Sourcegraph.
-1. You do a custom coding exercise that we designed which measures your understanding of how async execution works in JavaScript.
-   - You will choose a two hour timeframe to independently work on the exercise. You can choose any day and time; we just schedule an email.
-   - At your chosen date and time, we send you a zipped TypeScript project that contains instructions and some unit tests. You should have Node.js (>=8.16.0) installed on your computer.
-   - You can look up documentation on the internet while you are coding.
-   - After two hours, you will email us your solution as a zip file and we will get back to you on next steps within 2 business days.
-   - If we have questions about your code, we might schedule a 30 minute followup call.
+1. We set up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. You complete a 2-hour [coding exercise in TypeScript](code-exercise-typescript.md) that we designed to measure your understanding of how callbacks and asynchronous execution work.
 1. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
    - **Technical experience:** We ask you about your past work and accomplishments.

--- a/job-descriptions/software-engineer-frontend.md
+++ b/job-descriptions/software-engineer-frontend.md
@@ -46,7 +46,7 @@ We provide [competitive pay and equity](https://about.sourcegraph.com/handbook/p
 ## Interview process
 
 1. You [apply here](https://hire.withgoogle.com/public/jobs/sourcegraphcom/view/P_AAAAAADAAC5LV8Nx5OHMF9?trackingTag=careersRepository).
-1. We set up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. We set up a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
 1. You complete a 2-hour [coding exercise in TypeScript](code-exercise-typescript.md) that we designed to measure your understanding of how callbacks and asynchronous execution work.
 1. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.


### PR DESCRIPTION
There are two changes in this PR:

1. More transparently describe our Go code exercise and what it measures. We recently made this change for the frontend coding exercise: https://github.com/sourcegraph/careers/pull/73.
2. Moves the description of the coding exercises to separate files so they can be referenced from multiple job descriptions (i.e. code intel candidates can choose either).