### PR TITLE
Removing only designer wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We're hiring! Check out our open positions:
 - [Software Engineer - Code intelligence](job-descriptions/software-engineer-code-intelligence.md)
 - [Software Engineer - Distribution](job-descriptions/software-engineer-distribution.md)
 - [Software Engineer - Security](job-descriptions/software-engineer-security.md)
-- [UX Designer](https://github.com/sourcegraph/careers/blob/master/job-descriptions/ux-designer.md)
+- [Product Designer](https://github.com/sourcegraph/careers/blob/master/job-descriptions/ux-designer.md)
 - [Product Manager](https://github.com/sourcegraph/careers/blob/master/job-descriptions/product-manager.md)
 - [Customer Engineer](https://github.com/sourcegraph/careers/blob/master/job-descriptions/customer-engineer.md)
 

--- a/job-descriptions/ux-designer.md
+++ b/job-descriptions/ux-designer.md
@@ -1,8 +1,8 @@
 ![logo](https://sourcegraph.com/.assets/img/sourcegraph-light-head-logo.svg)
 
-# UX Designer
+# Product Designer
 
-We are looking for a self-motivated UX designer with the leadership skills to be the facilitator of design, and the pragmatism to be the person responsible for producing and executing the design. You will work collaboratively with product and engineering to create a highly functional and beautiful experience that delights a technical audience.
+We are looking for a self-motivated Product Designer with the leadership skills to be the facilitator of design, and the pragmatism to be the person responsible for producing and executing the design. You will work collaboratively with product and engineering to create a highly functional and beautiful experience that delights a technical audience.
 
 Developers [love our product](https://engineeringblog.yelp.com/2019/11/winning-the-hackathon-with-sourcegraph.html) and rely on it daily to ship and deploy better software. Our passionate users provide a constant stream of thoughtful feedback and love engaging with us to help them and their teams solve their toughest problems.
 

--- a/job-descriptions/ux-designer.md
+++ b/job-descriptions/ux-designer.md
@@ -2,7 +2,7 @@
 
 # UX Designer
 
-We are looking for a self-motivated UX designer with the leadership skills to be the facilitator of design, and the pragmatism to be the person responsible for producing and executing the design. You will work collaboratively with product and engineering to create a highly functional and beautiful experience that delights a technical audience. To start, you will be our only designer, and as we grow, you will help us build the design team and shape the design culture at Sourcegraph.
+We are looking for a self-motivated UX designer with the leadership skills to be the facilitator of design, and the pragmatism to be the person responsible for producing and executing the design. You will work collaboratively with product and engineering to create a highly functional and beautiful experience that delights a technical audience.
 
 Developers [love our product](https://engineeringblog.yelp.com/2019/11/winning-the-hackathon-with-sourcegraph.html) and rely on it daily to ship and deploy better software. Our passionate users provide a constant stream of thoughtful feedback and love engaging with us to help them and their teams solve their toughest problems.
 


### PR DESCRIPTION
I actually don't think anything else in the job description needs to change. 

@imtommyroberts - one question is if we should update this to be a "Product Designer" rather than "UX Designer" - I'm open to what you think will best resonate with the next designer we'd like to hire.