### PR TITLE
Add engineering manager distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Join us on our mission to make it so everyone, in every community, in every coun
 
 We're hiring! Check out our open positions:
 
+- [Engineering Manager - Distribution](job-descriptions/engineering-manager-distribution.md)
 - [Software Engineer - Frontend](job-descriptions/software-engineer-frontend.md)
 - [Software Engineer - Backend](job-descriptions/software-engineer-backend.md)
 - [Software Engineer - Code intelligence](job-descriptions/software-engineer-code-intelligence.md)

--- a/job-descriptions/engineering-manager-distribution.md
+++ b/job-descriptions/engineering-manager-distribution.md
@@ -29,7 +29,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 
 ## Interview process
 
-1. You [apply here](TODO).
+1. You [apply here](https://jobs.lever.co/sourcegraph/2c49d330-4185-42f6-a150-70ae64056474).
 1. We schedule a call with our VP of Engineering to learn more about you and answer any questions that you have about Sourcegraph.
 1. We schedule multiple remote interviews to determine if you would be a good fit for our team.
 1. We check your references.
@@ -37,4 +37,4 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 
-**[Click here to apply](TODO)**
+**[Click here to apply](https://jobs.lever.co/sourcegraph/2c49d330-4185-42f6-a150-70ae64056474)**

--- a/job-descriptions/engineering-manager-distribution.md
+++ b/job-descriptions/engineering-manager-distribution.md
@@ -9,8 +9,8 @@ We are looking for an experienced engineering leader to manage our [distribution
 - Update-to-date technical knowledge of relevant technologies like Go, Kubernetes, and Docker.
 - Track record of recruiting, developing, and retaining top engineering talent.
 - Excellent communication skills, especially in writing.
-- Minimum 3 years of experience as an engineering manager.
-- Minimum 3 years of experience as a software engineer.
+- Minimum 2 years of experience as an engineering manager.
+- Minimum 2 years of experience as a software engineer.
 
 ## Nice-to-haves
 

--- a/job-descriptions/engineering-manager-distribution.md
+++ b/job-descriptions/engineering-manager-distribution.md
@@ -1,0 +1,42 @@
+![logo](https://sourcegraph.com/.assets/img/sourcegraph-light-head-logo.svg)
+
+# Engineering Manager - Distribution
+
+We are looking for an experienced engineering leader to manage our [distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).
+
+## Qualifications
+
+- Update-to-date technical knowledge of relevant technologies like Go, Kubernetes, and Docker.
+- Track record of recruiting, developing, and retaining top engineering talent.
+- Excellent communication skills, especially in writing.
+- Minimum 3 years of experience as an engineering manager.
+- Minimum 3 years of experience as a software engineer.
+
+## Nice-to-haves
+
+- Published blog posts and/or tech talks about your work.
+- A network of excellent software engineers who would be interested to work with you again at Sourcegraph.
+
+## Learn more about us
+
+Sourcegraph is an equal opportunity workplace; we welcome people from all backgrounds and communities.
+
+To create a product that serves the needs of all developers, we are building a diverse [all-remote team](https://about.sourcegraph.com/company/remote) that is [distributed across the world](https://about.sourcegraph.com/company/team).
+
+We provide [competitive compensation](https://about.sourcegraph.com/handbook/people-ops/compensation) and [practical benefits](https://about.sourcegraph.com/handbook/people-ops/benefits-and-perks) to keep you happy and healthy so that you can do your best work.
+
+Learn more about what it is like to work at Sourcegraph by reading [our handbook](https://about.sourcegraph.com/handbook/).
+
+## Interview process
+
+1. You [apply here](TODO).
+1. We setup a call with our VP of Engineering to answer any questions that you have about Sourcegraph.
+1. We schedule remote interviews over video chat.
+1. We check your references.
+1. We make you a job offer.
+
+We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
+
+If you're interested in Sourcegraph but aren't yet ready to apply we are still happy to connect and answer any questions that you might have: [DM us on Twitter](https://twitter.com/srcgraph) or email hiring@sourcegraph.com.
+
+**[Click here to apply](TODO)**

--- a/job-descriptions/engineering-manager-distribution.md
+++ b/job-descriptions/engineering-manager-distribution.md
@@ -30,13 +30,11 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 ## Interview process
 
 1. You [apply here](TODO).
-1. We setup a call with our VP of Engineering to answer any questions that you have about Sourcegraph.
-1. We schedule remote interviews over video chat.
+1. We schedule a call with our VP of Engineering to learn more about you and answer any questions that you have about Sourcegraph.
+1. We schedule multiple remote interviews to determine if you would be a good fit for our team.
 1. We check your references.
 1. We make you a job offer.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
-
-If you're interested in Sourcegraph but aren't yet ready to apply we are still happy to connect and answer any questions that you might have: [DM us on Twitter](https://twitter.com/srcgraph) or email hiring@sourcegraph.com.
 
 **[Click here to apply](TODO)**


### PR DESCRIPTION
This job description is somewhat sparse for a few reasons:
1. The kinds of experienced/savy EMs that we are looking for are going to get more value out of an intro call than a job description.
1. The Distribution team page should be the source of truth for a short/inspiring description of what the team is and why it exists.
1. Not sweating the details in this job description makes it easier to merge sooner. We already had someone cold email us even thought we didn't have a job description posted, and I want to signal to others looking for jobs that we are in fact looking.