### PR TITLE
Update PM job title to Technical PM

### DIFF
--- a/job-descriptions/product-manager.md
+++ b/job-descriptions/product-manager.md
@@ -1,6 +1,6 @@
 ![logo](https://sourcegraph.com/.assets/img/sourcegraph-light-head-logo.svg)
 
-# Product Manager
+# Technical Product Manager
 
 You'll work with engineering, sales, marketing, and design to plan, ship, and grow usage and engagement in specific areas of our product. As an early member of our product team, you'll have significant product ownership and will communicate directly with our users to drive continuous improvement.
 


### PR DESCRIPTION
Given the technical requirements of this role I was given feedback that using the title of Technical PM is more accurate and will help get more candidates with the right profiles.