### PR TITLE
possible process change on security hire

### DIFF
--- a/job-descriptions/software-engineer-security.md
+++ b/job-descriptions/software-engineer-security.md
@@ -38,15 +38,14 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 ## Interview process
 
 1. You [apply here](https://jobs.lever.co/sourcegraph/c36db3e1-0ece-465d-ad7c-1eb6de9a4b22/apply).
-1. You speak with the VP of Engineering for 30 minutes. To prepare:
+1. You speak with the Security manager for 30 minutes. To prepare:
    - Read through [our handbook](https://github.com/sourcegraph/about) to learn more about how we operate and to find answers to common questions that you might have.
-   - Review the RFC template in the next step and write down any questions that you have.
-1. You write your first Sourcegraph [RFC](https://about.sourcegraph.com/handbook/communication/rfcs) by creating a new Google Doc using [this template](https://docs.google.com/document/d/1ol7aVXuXB7XL4DorOoxoDsaSyFI9Pv4Bcc1zfo-iLtw/edit#). We will review your RFC and may ask questions via comments directly on the document.
-1. You speak with the Sourcegraph Cloud engineering manager for 1 hour about your RFC.
-1. We schedule 4 hours of remote interviews over video chat across multiple days.
+1. You write a short security assessment, taking less than **30m** of your time, explaining a security vulnerability.
+1. We schedule remote interviews over video chat across multiple days.
    - 1h **Security architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
    - 1h **Technical experience:** We ask you about your past work and accomplishments.
    - 1h **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
+   - 30m **VP Engineering**
    - 30m **CTO**
    - 30m **CEO**
 1. We check your references.


### PR DESCRIPTION
The potential process change is highlighted here.  I'm thinking that we can ask new hires to explain a vulnerability, in plain English, and assess it's impact.  This will allow us to both gauge their understanding of security, and their ability to communicate.  To wit, we would be relying on an existing, public vulnerability, already disclosed in the [mitre database](https://cve.mitre.org/), and asking for a two to three paragraph response.